### PR TITLE
Dot repeat への対応を含めた提案

### DIFF
--- a/autoload/operator/insert.vim
+++ b/autoload/operator/insert.vim
@@ -28,29 +28,153 @@ set cpo&vim
 " Public API {{{1
 
 function! operator#insert#insert_i(motion_wise)
-  return s:operator_insert_i(a:motion_wise)
+  return s:operator_insert_origin('i', a:motion_wise)
 endfunction
 
 function! operator#insert#insert_a(motion_wise)
-  return s:operator_insert_a(a:motion_wise)
+  return s:operator_insert_origin('a', a:motion_wise)
+endfunction
+
+"}}}
+
+" Public, but it is *not* recommended to be used by users. {{{1
+
+" Set state to ground state. It is used when keymappings are triggered.
+function! operator#insert#ground_state()
+  call s:set_info('state', 0)
 endfunction
 
 "}}}
 
 " Private {{{1
 
-function! s:operator_insert_i(motion_wise)
-  call cursor(getpos("'[")[1:])
-  startinsert
+function! s:operator_insert_origin(ai, motion_wise)
+  " determine a insertion
+  let insertion = s:get_info('state') == 0
+        \  ? substitute(input("Insertion: ", ""), "\n", "", 'g')
+        \  : s:get_info('last_insertion')
+
+  if insertion != ''
+    " execute an action
+    call s:call_autocmd('OperatorInsertInsertPre')
+    call s:insert_{a:motion_wise}wise(a:ai, insertion)
+    call s:call_autocmd('OperatorInsertInsertPost')
+
+    " save history
+    call s:set_info('last_insertion', insertion)
+  endif
+
+  " excite state
+  call s:set_info('state', 1)
 endfunction
 
-function! s:operator_insert_a(motion_wise)
-  call cursor(getpos("']")[1:])
-  if col("']") >= col("$") - 1
-    startinsert!
+function! s:insert_charwise(ai, insertion)
+  if a:ai ==# 'i'
+    execute "normal! `[i" . a:insertion
   else
-    normal! l
-    startinsert
+    execute "normal! `]a" . a:insertion
+  endif
+endfunction
+
+function! s:insert_linewise(ai, insertion)
+  let [head, tail] = [line("'["), line("']")]
+
+  if a:ai ==# 'i'
+    " not sure... removing '^' might be more natural...
+    execute "'[,']normal! ^i" . a:insertion
+  else
+    execute "'[,']normal! $a" . a:insertion
+  endif
+
+  " set marks as wrapping whole lines
+  call setpos("'[", [0, head, 0, 0])
+  call setpos("']", [0, tail, col([tail, '$']), 0])
+endfunction
+
+function! s:insert_blockwise(ai, insertion)
+  let processed = []
+
+  if a:ai ==# 'i'
+    " lines: [lnum, length]
+    let lines = map(range(line("'["), line("']")),
+          \           '[v:val, strlen(getline(v:val))]')
+
+    let col   = col("'[")
+    for line in lines
+      if line[1] >= col
+        call cursor(line[0], col)
+        execute "normal! i" . a:insertion
+        let processed += [line[0]]
+      elseif line[1] == col - 1
+        call cursor(line[0], col)
+        execute "normal! a" . a:insertion
+        let processed += [line[0]]
+      endif
+    endfor
+  else
+    " lines: [lnum, length]
+    let lines = map(range(line("'["), line("']")),
+          \           '[v:val, strlen(getline(v:val))]')
+
+    let col = col("']")
+    for line in lines
+      if line[1] >= col
+        call cursor(line[0], col)
+        execute "normal! a" . a:insertion
+        let processed += [line[0]]
+      endif
+    endfor
+  endif
+
+  " set marks for the topleft and bottomright edge of the processed lines
+  if processed != []
+    call setpos("'[", [0, processed[0], col("'["), 0])
+    call setpos("']", [0, processed[-1], col("']") - 1, 0])
+  endif
+endfunction
+
+
+
+" History and state management
+" The required information is stored to buffer local variable named
+" 'b:operator_insert_info' since 'operatorfunc' option is buffer local. There
+" are three keys, 'state', 'last_insertion', and, 'last_target'.
+
+" The 'state' keeps managed to distinguish whether the operatorfunc was called
+" by a keymapping or by the dot command.
+" get_state() == 0 : called by a keymapping
+" get_state() == 1 : called by the dot command
+
+" The 'last_insertion' is stored for dot-repeat.
+
+function! s:get_info(name)
+  if !exists('b:operator_insert_info')
+    let b:operator_insert_info = {}
+    let b:operator_insert_info.state = 0
+    let b:operator_insert_info.last_insertion = ''
+  endif
+  return b:operator_insert_info[a:name]
+endfunction
+
+function! s:set_info(name, value)
+  if !exists('b:operator_insert_info')
+    let b:operator_insert_info = {}
+    let b:operator_insert_info.state = 0
+    let b:operator_insert_info.last_insertion = ''
+  endif
+  let b:operator_insert_info[a:name] = a:value
+endfunction
+
+
+
+" Userdefined autocmd events
+" OperatorInsertInsertPre  : Ignited prior to insert a insertion.
+" OperatorInsertInsertPost : Ignited after inserting a insertion.
+" These events are prepared mainly to suppress unwanted affection from
+" auto-complete plugins.
+function! s:call_autocmd(name)
+  if exists('#' . a:name)
+    execute 'doautocmd <nomodeline> ' . a:name
   endif
 endfunction
 

--- a/autoload/operator/insert/textobj.vim
+++ b/autoload/operator/insert/textobj.vim
@@ -97,7 +97,7 @@ let [s:get_info, s:set_info, s:add_info]
 " NOTE: If the searched word can not be found in 'cold' calling, the 'gn'
 "       (or 'gN') command in s:operator_range_capture can not find the target
 "       and s:operator_range_capture is cancelled. As a result,
-"       s:range_capturer will return s:null_region and textobjects will decide
+"       s:capture_range will return s:null_region and textobjects will decide
 "       to cancel the operator. (This is because 'gn' and 'gN' command do not
 "       issue any exception like vim error 482 even if the searched word can
 "       not be found.)
@@ -138,13 +138,13 @@ function! s:executer(ai, count, textobj, next)
     let last_target = s:get_info('last_target')
     try
       for i in [1, 2]
-        let target = s:range_capturer(1, a:textobj)
+        let target = s:capture_range(1, a:textobj)
         " FIXME: Am I sure that this is the appropriate condition?
         if target != last_target | break | endif
         execute "normal! " . a:next
       endfor
 
-      let target = s:range_capturer(l:count, a:textobj)
+      let target = s:capture_range(l:count, a:textobj)
       let [head, tail] = target
     catch /^Vim\%((\a\+)\)\=:E\%(384\|385\|486\)/
       call s:error_handling_no_target(view, lt, gt)
@@ -152,12 +152,12 @@ function! s:executer(ai, count, textobj, next)
     endtry
   else
     " Keymapping calling or 'cold' calling. Work as usual.
-    let [head, tail] = s:range_capturer(l:count, a:textobj)
+    let [head, tail] = s:capture_range(l:count, a:textobj)
   endif
 
   if head != s:null_pos && tail != s:null_pos
     " open foldings
-    let opened_fold = s:fold_opener(head, tail)
+    let opened_fold = s:open_fold(head, tail)
 
     " highlight target if it is called from keymappings (i.e. not dot-repeat)
     if !state && g:operator#insert#textobj#open_fold
@@ -193,7 +193,7 @@ function! s:executer(ai, count, textobj, next)
   endif
 endfunction
 
-function! s:range_capturer(count, textobj)
+function! s:capture_range(count, textobj)
   let s:range = s:null_region
   let operatorfunc  = &operatorfunc
   let &operatorfunc = '<SID>operator_range_capture'
@@ -226,7 +226,7 @@ function! s:error_handling_no_target(view, lt, gt)
   call operator#insert#deactivate()
 endfunction
 
-function! s:fold_opener(head, tail)
+function! s:open_fold(head, tail)
   let opened_fold = []
   for lnum in range(a:head[0], a:tail[0])
     while 1

--- a/autoload/operator/insert/textobj.vim
+++ b/autoload/operator/insert/textobj.vim
@@ -1,0 +1,258 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+" Public API {{{1
+
+function! operator#insert#textobj#gn_for_operator_insert_i()
+  return s:fixer('i')
+endfunction
+
+function! operator#insert#textobj#gN_for_operator_insert_a()
+  return s:fixer('a')
+endfunction
+
+function! operator#insert#textobj#executer(ai, count, textobj, next)
+  return s:executer(a:ai, a:count, a:textobj, a:next)
+endfunction
+
+"}}}
+
+" Private {{{1
+
+" The definition of null position and region
+let s:null_pos    = [0, 0]
+let s:null_region = [s:null_pos, s:null_pos]
+
+" break the seal of funcrefs
+" NOTE: s:set_info() should be called only in the function s:prototype except
+"       for the case of 'state' key as possible. Otherwise it is really easy
+"       to mess up.
+let [s:get_info, s:set_info, s:add_info]
+      \   = operator#insert#funcref_mediator(['get_info', 'set_info', 'add_info'])
+
+
+
+" NOTE: These Textobjects are expected to be used like this:
+"
+"           nmap <Leader>ign
+"             \  <Plug>(operator-insert-i)<Plug>(gn-for-operator-insert-i)
+"
+"       This method do not affect to the other usage of 'gn' with other
+"       operators. A known problem is that one can not give {count} before
+"       'gn'. If making several sets of keymappings, it is enough for practical
+"       uses although I know it is not smart way...
+"
+"           nmap <Leader>i2gn
+"             \  <Plug>(operator-insert-i)2<Plug>(gn-for-operator-insert-i)
+"           nmap <Leader>i3gn
+"             \  <Plug>(operator-insert-i)3<Plug>(gn-for-operator-insert-i)
+"
+"       Actually these textobjects could safely replace 'gn' and 'gN' due to
+"       the fail-safe. So it is safe even if a user makes mappings mistakenly.
+"
+"           nmap gn <Plug>(gn-for-operator-insert-i)
+"           nmap gN <Plug>(gN-for-operator-insert-a)
+"
+"       These mappings shows its unique behavior only when it is employed with
+"       the correspondent operator-insert. Otherwise, when it is employed with
+"       other operators, operator#insert#textobj#gn_for_operator_insert_i (or
+"       operator#insert#textobj#gN_for_operator_insert_a) is called at first
+"       keymapping call and it returns 'gn' (or 'gN') with <expr> mapping.
+"       After that, never called these functions, just the original 'gn' (or
+"       gN) works as usual. If I do not use <expr>, then the same function is
+"       always called in each 'gn' (or 'gN') key presses, and there would be a
+"       irritating and indelible echoing at command-line.
+"
+" NOTE: If they are called in 'hot' state, they will try to search the next
+"       target textobject (it is different from the one which is processed a
+"       little while ago!). For example, a user searched 'bar' and insert
+"       'foo' then:
+"
+"       foobar    bar   bar
+"
+"       At this moment, the cursor is on the last 'o' of foo. Thus the next
+"       target is also the first 'bar', never reaches to the second 'bar'
+"       usually. The alternative textobjects are served to overcome this
+"       problem. The textobjects push 'n' (or 'N') twice to skip the first
+"       'bar'. The first 'n' brings the cursor on the first 'bar' and the
+"       following 'n' brings on the second 'bar' which is the very what we
+"       want to process. (NOTE: If the cursor is on the searched word, 'gn'
+"       and 'gN' do not move and process the current word.)
+"
+"       However it is not always correct. For instance if the searched pattern
+"       is '\<bar', 'foobar' is no longer matched with '\<bar', therefore the
+"       first 'n' brings to the appropriate target. The operator-insert saves
+"       the region of the last processed target, these textobjects use it to
+"       judge whether the second 'n' command is required or not.
+"       If the searched command has flag like '/bar/e+1', there is the same
+"       problem. In addition, there is the case that it is not needed to try
+"       the first 'n' command.
+"
+"       If there is only one searched word in the buffer, then try 'n' command
+"       twice and exit normally to execute for it when 'wrapscan' option is on.
+"
+"       If the searched word can not be found, then immediately quit loop and
+"       cancel the operator.
+"
+" NOTE: If the searched word can not be found in 'cold' calling, the 'gn'
+"       (or 'gN') command in s:operator_range_capture can not find the target
+"       and s:operator_range_capture is cancelled. As a result,
+"       s:range_capturer will return s:null_region and textobjects will decide
+"       to cancel the operator. (This is because 'gn' and 'gN' command do not
+"       issue any exception like vim error 482 even if the searched word can
+"       not be found.)
+
+" Alternative gn, gN
+
+function! s:fixer(ai)
+  let [operatorfunc, textobj, next] = a:ai ==# 'i'
+        \                           ? ['operator#insert#insert_i', 'gn', 'n']
+        \                           : ['operator#insert#insert_a', 'gN', 'N']
+
+  if !(v:operator ==# 'g@' && &operatorfunc ==# operatorfunc)
+    " fail-safe
+    let cmd = textobj
+  else
+    let cmd = printf(":\<C-u>call operator#insert#textobj#executer('%s',%d,'%s','%s')\<CR>",
+          \           a:ai, v:count1, textobj, next)
+  endif
+
+  return cmd
+endfunction
+
+function! s:executer(ai, count, textobj, next)
+  let state = s:get_info('state')
+  let l:count = (state ? v:count1 : a:count)
+
+  " save view
+  let view = winsaveview()
+
+  " save marks, '<, '>
+  let lt = getpos("'<")
+  let gt = getpos("'>")
+  call s:set_info('visualmarks', [lt, gt])
+
+
+  if state == 2
+    " 'Hot' calling. Skip the closest target if in super-excited state
+    let last_target = s:get_info('last_target')
+    try
+      for i in [1, 2]
+        let target = s:range_capturer(1, a:textobj)
+        " FIXME: Am I sure that this is the appropriate condition?
+        if target != last_target | break | endif
+        execute "normal! " . a:next
+      endfor
+
+      let target = s:range_capturer(l:count, a:textobj)
+      let [head, tail] = target
+    catch /^Vim\%((\a\+)\)\=:E\%(384\|385\|486\)/
+      call s:error_handling_no_target(view, lt, gt)
+      call s:set_info('visualmarks', s:null_region)
+    endtry
+  else
+    " Keymapping calling or 'cold' calling. Work as usual.
+    let [head, tail] = s:range_capturer(l:count, a:textobj)
+  endif
+
+  if head != s:null_pos && tail != s:null_pos
+    " open foldings
+    let opened_fold = s:fold_opener(head, tail)
+
+    " highlight target if it is called from keymappings (i.e. not dot-repeat)
+    if !state && g:operator#insert#textobj#open_fold
+      if v:version > 704 || v:version == 704 && has('patch343')
+        let id = [matchaddpos("IncSearch", [[line("'["), col("'["), tail[1] - head[1] + 1]])]
+      else
+        " It seems the pattern \%'[ has some bug... Do not use it.
+        let id = [matchadd("IncSearch", printf('\%%%sl\%%>%sc.*\%%<%sc', line("'["), col("'[") - 1, col("']") + 1))]
+      endif
+      call s:add_info('highlight', id)
+
+      redraw
+    endif
+
+    " select range
+    call cursor(head)
+    normal! v
+    call cursor(tail)
+
+    " counter measure for the 'selection' option being 'exclusive'
+    if &selection == 'exclusive'
+      normal! l
+    endif
+
+    " save the view to b:operator_insert_info
+    call s:set_info('view', view)
+
+    " pass the list of opened foldings
+    call s:set_info('opened_fold', opened_fold)
+  else
+    " no target
+    call s:error_handling_no_target(view, lt, gt)
+  endif
+endfunction
+
+function! s:range_capturer(count, textobj)
+  let s:range = s:null_region
+  let operatorfunc  = &operatorfunc
+  let &operatorfunc = '<SID>operator_range_capture'
+  try
+    execute 'normal! g@' . a:count . a:textobj
+  finally
+    let &operatorfunc = operatorfunc
+    return s:range
+  endtry
+endfunction
+
+function! s:operator_range_capture(motion_wise)
+  let s:range = [getpos("'[")[1:2], getpos("']")[1:2]]
+endfunction
+
+function! s:error_handling_no_target(view, lt, gt)
+  " echo error message
+  echohl ErrorMsg
+  echo 'operator-insert: No target has been found.'
+  echohl NONE
+
+  " restore view
+  call winrestview(a:view)
+
+  " restore visualmarks
+  call setpos("'<", a:lt)
+  call setpos("'>", a:gt)
+
+  " deactivate operator-insert
+  call operator#insert#deactivate()
+endfunction
+
+function! s:fold_opener(head, tail)
+  let opened_fold = []
+  for lnum in range(a:head[0], a:tail[0])
+    while 1
+      let fold_start = foldclosed(lnum)
+      if fold_start < 0 | break | endif
+
+      execute lnum . 'foldopen'
+      let opened_fold += [fold_start]
+    endwhile
+  endfor
+
+  return opened_fold
+endfunction
+
+"}}}
+
+" Options {{{1
+
+" Manage the behavior when the target textobject is inside foldings.
+let g:operator#insert#textobj#open_fold =
+      \ get(g:, 'operator#insert#textobj#open_fold', 1)
+
+"}}}
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" __END__ "{{{1
+" vim: foldmethod=marker

--- a/autoload/operator/insert/textobj.vim
+++ b/autoload/operator/insert/textobj.vim
@@ -61,7 +61,7 @@ let [s:get_info, s:set_info, s:add_info]
 "       After that, never called these functions, just the original 'gn' (or
 "       gN) works as usual. If I do not use <expr>, then the same function is
 "       always called in each 'gn' (or 'gN') key presses, and there would be a
-"       irritating and indelible echoing at command-line.
+"       irritating and unsuppressable echoing at command-line.
 "
 " NOTE: If they are called in 'hot' state, they will try to search the next
 "       target textobject (it is different from the one which is processed a

--- a/doc/operator-insert.txt
+++ b/doc/operator-insert.txt
@@ -95,10 +95,6 @@ These behavior might not be different from all your expectations, but it is
 useful enough |v_b_I| and |v_b_A| for the purpose, I guess.
 
 ------------------------------------------------------------------------------
-Note that inserted texts can not include line-breaks. They will be removed
-before inserting a text.
-
-------------------------------------------------------------------------------
 The operators support |single-repeat| by dot |.| command. However the behavior
 would not be what you want when you use it with |gn| and |gN|. In that case
 try |<Plug>(gn-for-operator-insert-i)| and |<Plug>(gN-for-operator-insert-a)|,

--- a/doc/operator-insert.txt
+++ b/doc/operator-insert.txt
@@ -36,8 +36,63 @@ Changelog		|operator-insert-changelog|
 ==============================================================================
 INTRODUCTION					*operator-insert-introduction*
 
-operator-insert is an operator for inserting to
-head(or tail) of textobject.
+*operator-insert* is an operator for inserting to head(or tail) of textobject.
+
+This operator works differently with character-wise, line-wise, block-wise
+selection areas.
+
+Character-wise~
+The operator may work as you expect, that is, inserting text to head or tail
+of selection areas.
+
+Line-wise~
+Inserting texts in front of the first non-whitespace characters or just after
+the last character in the lines. If empty lines are included in the range,
+texts are inserted to the beginnings of the lines.
+
+Before:
+>
+	foo
+		bar
+	
+	baz
+<
+
+After:
+>
+	(Insertion)foo
+		(Insertion)bar
+	(Insertion)
+	(Insertion)baz
+<
+
+Block-wise~
+Inserting texts almost as you expect, but do not insert to the lines shorter
+than the current cursor column. Look the following example.
+
+>
+	foo
+	bar
+	
+	baz
+<
+
+Select block-wise the second column and insert texts. Then you will get:
+>
+	f(Insertion)oo
+	b(Insertion)ar
+	
+	b(Insertion)az
+<
+Since the third line is shorter than the head column of the selection, the
+insertion is not inserted.
+
+These behavior might not be different from all your expectations, but it is
+useful enough |v_b_I| and |v_b_A| for the purpose, I guess.
+------------------------------------------------------------------------------
+Note that inserted texts can not include line-breaks. They will be removed
+before inserting a text.
+
 
 
 Requirements:
@@ -45,8 +100,6 @@ Requirements:
 
 Latest version:
 https://github.com/deris/vim-operator-insert
-
-
 ==============================================================================
 INTERFACE					*operator-insert-interface*
 
@@ -55,14 +108,14 @@ MAPPINGS					*operator-insert-mappings*
 
 <Plug>(operator-insert-i)			*<Plug>(operator-insert-i)*
 <Plug>(operator-insert-a)			*<Plug>(operator-insert-a)*
-			These mappings are defined in Normal mode, Visual mode
-			and Operator-pending mode.
+			These mappings are defined in Normal mode and Visual
+			mode.
 
 
 ==============================================================================
 EXAMPLES					*operator-insert-examples*
 
-" By default, no mapping is set, so you must map key like following at first.
+By default, no mapping is set, so you must map key like following at first.
 nmap <Leader>i  <Plug>(operator-insert-i)
 nmap <Leader>a  <Plug>(operator-insert-a)
 

--- a/doc/operator-insert.txt
+++ b/doc/operator-insert.txt
@@ -38,14 +38,14 @@ Changelog		|operator-insert-changelog|
 ==============================================================================
 INTRODUCTION					*operator-insert-introduction*
 
-*operator-insert* is an operator for inserting to head(or tail) of textobject.
+*operator-insert* are operators for inserting to head(or tail) of textobject.
 
-This operator works differently with character-wise, line-wise, block-wise
+Thiese operators work differently with character-wise, line-wise, block-wise
 selection areas.
 
 Character-wise~
-The operator may work as you expect, that is, inserting text to head or tail
-of selection areas.
+These operators may work as you expect, that is, inserting text to head or
+tail of selection areas.
 
 Line-wise~
 Inserting texts in front of the first non-whitespace characters or just after
@@ -99,11 +99,10 @@ Note that inserted texts can not include line-breaks. They will be removed
 before inserting a text.
 
 ------------------------------------------------------------------------------
-These operators support |single-repeat| by dot |.| command. However the
-behavior would not be what you want when you use it with |gn| and |gN|. In
-that case try |<Plug>(gn-for-operator-insert-i)| and
-|<Plug>(gN-for-operator-insert-a)|, they might be helpful. Please take a look
-|operator-insert-examples|.
+The operators support |single-repeat| by dot |.| command. However the behavior
+would not be what you want when you use it with |gn| and |gN|. In that case
+try |<Plug>(gn-for-operator-insert-i)| and |<Plug>(gN-for-operator-insert-a)|,
+they might be helpful. Please take a look |operator-insert-examples|.
 
 
 
@@ -133,7 +132,7 @@ MAPPINGS					*operator-insert-mappings*
 CUSTOMIZATION				*operator-insert-customization*
 
 The completion in a insertion input~	*g:operator#insert#completefunc*
-The operator has a simple buffer completion function in the input mode of
+The operators have a simple buffer completion function in the input mode of
 insertion. It gathers words consisting of more than three characters from
 visible range of lines. If you do not need this function, then please set
 |g:operator#insert#completefunc| as an empty string in your vimrc:
@@ -160,6 +159,49 @@ vimrc.
 	let g:operator#insert#textobj#open_fold = 0
 <
 Opened foldings are automatically closed if an action is cancelled.
+
+
+
+					*g:operator#insert#dummycursor*
+Change the highlight coloring of dummy cursors~
+The operators put dummy cursors to highlight the positions which would be
+inserted texts. You can change the coloring of the dummy cursors with this
+option. If you set the name of an existing highlight group, then the coloring
+is linked to that group.
+>
+	let g:operator#insert#dummycursor = 'Cursor'
+<
+Or you could pass the dictionary variable which contains the information for
+highlight. It could have keys named as following highlight arguments. Other
+keys would be ignored.
+
+	term		|highlight-term|
+	cterm		|highlight-cterm|
+	ctermfg		|highlight-ctermfg|
+	ctermbg		|highlight-ctermbg|
+	gui		|highlight-gui|
+	guifg		|highlight-guifg|
+	guibg		|highlight-guibg|
+	guisp		|highlight-guisp|
+
+Their values should be correspondent attributes or colors, available
+values are described at |syntax|. For example:
+>
+	let g:operator#insert#dummycursor = {
+		\	'ctermfg': '15',
+		\	'ctermbg': '0',
+		\	'guifg': '#ffffff'
+		\	'guibg': '#000000'
+		\	}
+<
+If you do not prefer the dummy cursor highlighting, please set the value as
+an empty string.
+>
+	let g:operator#insert#dummycursor = ''
+<
+
+
+
 
 ==============================================================================
 EXAMPLES					*operator-insert-examples*
@@ -216,6 +258,11 @@ BUGS						*operator-insert-bugs*
 - Embedding the special keys <BS>, <C-h>, <C-w>, <C-d>, <C-t> is not
   prohibited. However it may cause some problem to the behaviors of the
   auxiliary textobjects.
+
+- The dummy cursor function can not highlight empty lines.
+
+- The dummy cursor might be displayed weird if there is an tab character or
+  a multi-byte character.
 
 
 ==============================================================================

--- a/doc/operator-insert.txt
+++ b/doc/operator-insert.txt
@@ -132,6 +132,22 @@ MAPPINGS					*operator-insert-mappings*
 ------------------------------------------------------------------------------
 CUSTOMIZATION				*operator-insert-customization*
 
+The completion in a insertion input~	*g:operator#insert#completefunc*
+The operator has a simple buffer completion function in the input mode of
+insertion. It gathers words consisting of more than three characters from
+visible range of lines. If you do not need this function, then please set
+|g:operator#insert#completefunc| as an empty string in your vimrc:
+>
+	let g:operator#insert#completefunc = ''
+<
+
+If you want to customize the completion, please see |:command-completion| and
+|:command-completion-custom|.
+
+The default value is "custom,operator#insert#complete_from_visible_lines".
+
+
+
 					*g:operator#insert#textobj#open_fold*
 Manage the behavior when the target textobject is inside foldings~
 This option changes the behavior of auxiliary textobjects,
@@ -165,8 +181,7 @@ or, if you do not care to overwrite them, just like this:
 nmap gn <Plug>(gn-for-operator-insert-i)
 nmap gN <Plug>(gN-for-operator-insert-a)
 
-These mappings are safely replace the function of |gn| and |gN|. This should
-still be OK.
+These mappings are safely replace the function of |gn| and |gN| as possible.
 
 Because of the position of cursor after an action, these operators repeatedly
 insert texts for the same target even when they are used with |gn| and |gN|.

--- a/doc/operator-insert.txt
+++ b/doc/operator-insert.txt
@@ -1,4 +1,5 @@
-*operator-insert.txt*	operator-insert is an operator for inserting to head(or tail) of textobject
+*operator-insert.txt*	operator-insert is an operator for inserting to
+			head(or tail) of textobject
 
 Version 0.1.0
 Copyright (C) 2013-2014 deris <deris0126@gmail.com>
@@ -28,6 +29,7 @@ CONTENTS					*operator-insert-contents*
 Introduction		|operator-insert-introduction|
 Interface		|operator-insert-interface|
   Key Mappings		  |operator-insert-key-mappings|
+  Customization		  |operator-insert-customization|
 Examples		|operator-insert-examples|
 Bugs			|operator-insert-bugs|
 Changelog		|operator-insert-changelog|
@@ -87,11 +89,21 @@ Select block-wise the second column and insert texts. Then you will get:
 Since the third line is shorter than the head column of the selection, the
 insertion is not inserted.
 
+
+
 These behavior might not be different from all your expectations, but it is
 useful enough |v_b_I| and |v_b_A| for the purpose, I guess.
+
 ------------------------------------------------------------------------------
 Note that inserted texts can not include line-breaks. They will be removed
 before inserting a text.
+
+------------------------------------------------------------------------------
+These operators support |single-repeat| by dot |.| command. However the
+behavior would not be what you want when you use it with |gn| and |gN|. In
+that case try |<Plug>(gn-for-operator-insert-i)| and
+|<Plug>(gN-for-operator-insert-a)|, they might be helpful. Please take a look
+|operator-insert-examples|.
 
 
 
@@ -111,19 +123,84 @@ MAPPINGS					*operator-insert-mappings*
 			These mappings are defined in Normal mode and Visual
 			mode.
 
+<Plug>(gn-for-operator-insert-i)	*<Plug>(gn-for-operator-insert-i)*
+<Plug>(gN-for-operator-insert-a)	*<Plug>(gN-for-operator-insert-a)*
+			These auxiliary mappings serve you alternative
+			behaviors for |gn| and |gN| with the operators. See
+			|operator-insert-examples|.
+
+------------------------------------------------------------------------------
+CUSTOMIZATION				*operator-insert-customization*
+
+					*g:operator#insert#textobj#open_fold*
+Manage the behavior when the target textobject is inside foldings~
+This option changes the behavior of auxiliary textobjects,
+|<Plug>(gn-for-operator-insert-i)| and |<Plug>(gN-for-operator-insert-a)|,
+when the target textobject is found in foldings. If the value is not zero,
+opening foldings and show where is the target. If you do not prefer to move
+the viewpoint before a execution of an action, set the value as 0 in your
+vimrc.
+>
+	let g:operator#insert#textobj#open_fold = 0
+<
+Opened foldings are automatically closed if an action is cancelled.
 
 ==============================================================================
 EXAMPLES					*operator-insert-examples*
 
 By default, no mapping is set, so you must map key like following at first.
 nmap <Leader>i  <Plug>(operator-insert-i)
+xmap <Leader>i  <Plug>(operator-insert-i)
 nmap <Leader>a  <Plug>(operator-insert-a)
+xmap <Leader>a  <Plug>(operator-insert-a)
 
+If you want to use them with |gn| and |gN|, then strongly recommended to add
+following settings.
+
+nmap <Leader>ign <Plug>(operator-insert-i)<Plug>(gn-for-operator-insert-i)
+nmap <Leader>agN <Plug>(operator-insert-a)<Plug>(gN-for-operator-insert-a)
+
+or, if you do not care to overwrite them, just like this:
+
+nmap gn <Plug>(gn-for-operator-insert-i)
+nmap gN <Plug>(gN-for-operator-insert-a)
+
+These mappings are safely replace the function of |gn| and |gN|. This should
+still be OK.
+
+Because of the position of cursor after an action, these operators repeatedly
+insert texts for the same target even when they are used with |gn| and |gN|.
+For example, search a pattern "\w\+", then it matches with "foo" and "bar".
+>
+	" foo bar
+<
+Assuming that the cursor is on the beginning of the line, if a text is
+inserted to the head with |gn|, then you get:
+>
+	" (Insertion)foo bar
+<
+At this moment the cursor is on the last character of the insertion, that is
+")". Thus the next target of dot |.| repeat is also "foo" because it is the
+closest searched word, never reaches to "bar" usually. However, if you would
+apply above additional settings, you could skip "foo" only just after
+inserting a text by these operators. Note that after moving cursor or edit
+texts, dot |.| repeat works as same as usual.
+
+After dot repeat:
+>
+	Without above settings
+	" (Insertion)(Insertion)foo bar
+
+	With above settings
+	" (Insertion)foo (Insertion)bar
+<
 
 ==============================================================================
 BUGS						*operator-insert-bugs*
 
-- Currently, there is no known issue.
+- Embedding the special keys <BS>, <C-h>, <C-w>, <C-d>, <C-t> is not
+  prohibited. However it may cause some problem to the behaviors of the
+  auxiliary textobjects.
 
 
 ==============================================================================

--- a/plugin/operator/insert.vim
+++ b/plugin/operator/insert.vim
@@ -31,8 +31,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-call operator#user#define('insert-i', 'operator#insert#insert_i', 'call operator#insert#ground_state()')
-call operator#user#define('insert-a', 'operator#insert#insert_a', 'call operator#insert#ground_state()')
+call operator#user#define('insert-i', 'operator#insert#i', 'call operator#insert#ground_state()')
+call operator#user#define('insert-a', 'operator#insert#a', 'call operator#insert#ground_state()')
 
 onoremap <silent><expr> <Plug>(gn-for-operator-insert-i) operator#insert#textobj#gn_for_operator_insert_i()
 onoremap <silent><expr> <Plug>(gN-for-operator-insert-a) operator#insert#textobj#gN_for_operator_insert_a()

--- a/plugin/operator/insert.vim
+++ b/plugin/operator/insert.vim
@@ -31,8 +31,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-call operator#user#define('insert-i', 'operator#insert#i', 'call operator#insert#ground_state()')
-call operator#user#define('insert-a', 'operator#insert#a', 'call operator#insert#ground_state()')
+call operator#user#define('insert-i', 'operator#insert#insert_i', 'call operator#insert#ground_state()')
+call operator#user#define('insert-a', 'operator#insert#insert_a', 'call operator#insert#ground_state()')
 
 onoremap <silent><expr> <Plug>(gn-for-operator-insert-i) operator#insert#textobj#gn_for_operator_insert_i()
 onoremap <silent><expr> <Plug>(gN-for-operator-insert-a) operator#insert#textobj#gN_for_operator_insert_a()

--- a/plugin/operator/insert.vim
+++ b/plugin/operator/insert.vim
@@ -34,6 +34,9 @@ set cpo&vim
 call operator#user#define('insert-i', 'operator#insert#insert_i', 'call operator#insert#ground_state()')
 call operator#user#define('insert-a', 'operator#insert#insert_a', 'call operator#insert#ground_state()')
 
+onoremap <silent><expr> <Plug>(gn-for-operator-insert-i) operator#insert#textobj#gn_for_operator_insert_i()
+onoremap <silent><expr> <Plug>(gN-for-operator-insert-a) operator#insert#textobj#gN_for_operator_insert_a()
+
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/operator/insert.vim
+++ b/plugin/operator/insert.vim
@@ -31,8 +31,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-call operator#user#define('insert-i', 'operator#insert#insert_i')
-call operator#user#define('insert-a', 'operator#insert#insert_a')
+call operator#user#define('insert-i', 'operator#insert#insert_i', 'call operator#insert#ground_state()')
+call operator#user#define('insert-a', 'operator#insert#insert_a', 'call operator#insert#ground_state()')
 
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
不躾なプルリクエストですいません。ドットリピートへの対応ができると便利かと思い書きました。あまりにも使用感を大きく変えるのでもちろん蹴っていただいても構わないです。一応提案して意見を伺おうとおもった次第です。

四つのコミットがあって、大事なのが最初の二つです。始めのが `input()` インターフェースを使ったドットリピートへの対応。二つ目のがテキストオブジェクト `gn` および `gN` と組み合わせた場合に発生する問題への解決案となっています。後の二つはインサートモードに入らないために補完機能を使えないので代用の簡易的な単語補完機能と `input()` 入力受付中はカーソルが消えるので代用のハイライト機能です。
